### PR TITLE
Use account name for messages

### DIFF
--- a/src/components/Profile/UserProfileManager.tsx
+++ b/src/components/Profile/UserProfileManager.tsx
@@ -31,6 +31,7 @@ import {
   Minus
 } from 'lucide-react';
 import { authService, AppUser, UserRole, Permission, SocialProvider } from '../../services/authService';
+import chatService from '../../services/chatService';
 // import { useAuth } from '../../contexts/AuthContext';
 
 interface UserProfileManagerProps {
@@ -232,6 +233,16 @@ const UserProfileManager: React.FC<UserProfileManagerProps> = ({
 
       // Update user profile
       await authService.updateUserProfile(user.uid, updates);
+
+      // Update chat user name if display name changed
+      if (formData.displayName && formData.displayName !== user.displayName) {
+        try {
+          await chatService.updateChatUserName(formData.displayName);
+        } catch (chatError) {
+          console.warn('Failed to update chat user name:', chatError);
+          // Don't fail the entire save operation if chat update fails
+        }
+      }
 
       // Update local state
       const updatedUser = { ...user, ...updates };


### PR DESCRIPTION
Display authenticated user names in chat instead of random ones and synchronize chat names with user profile updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-19760dcf-4165-426b-9801-e4a432220353">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19760dcf-4165-426b-9801-e4a432220353">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

