### PR TITLE
Fix unpinning announcement bug

### DIFF
--- a/src/components/Announcements/AnnouncementCard.tsx
+++ b/src/components/Announcements/AnnouncementCard.tsx
@@ -116,16 +116,18 @@ const AnnouncementCard: React.FC<AnnouncementCardProps> = ({
           </div>
         </div>
         
-        {/* Pin Toggle Button - Only show when not pinned */}
-        {!announcement.pinned && (
-          <button
-            onClick={handlePinToggle}
-            className="ml-4 p-2 rounded-xl transition-all duration-200 text-gray-400 hover:text-primary-500 hover:bg-primary-50"
-            title="Pin announcement"
-          >
-            <Pin className="w-4 h-4" />
-          </button>
-        )}
+        {/* Pin/Unpin Toggle Button */}
+        <button
+          onClick={handlePinToggle}
+          className={`ml-4 p-2 rounded-xl transition-all duration-200 ${
+            announcement.pinned 
+              ? 'text-primary-500 hover:text-primary-600 hover:bg-primary-100' 
+              : 'text-gray-400 hover:text-primary-500 hover:bg-primary-50'
+          }`}
+          title={announcement.pinned ? "Unpin announcement" : "Pin announcement"}
+        >
+          <Pin className={`w-4 h-4 ${announcement.pinned ? 'fill-current' : ''}`} />
+        </button>
       </div>
 
       {/* Content */}


### PR DESCRIPTION
Allow unpinning of announcements by making the pin/unpin button always visible and dynamically styled.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd55608a-620c-4a91-8e09-ab7fbbb5cc5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd55608a-620c-4a91-8e09-ab7fbbb5cc5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

