### PR TITLE
Fix Cloud Functions Authentication Parameter Mismatch

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -137,11 +137,8 @@ export const updateUserRole = functions.https.onCall(async (data: any, context: 
 });
 
 // CRITICAL: Admin update event function
-export const adminUpdateEvent = functions.https.onCall(async (request: any) => {
+export const adminUpdateEvent = functions.https.onCall(async (data: any, context: functions.https.CallableContext) => {
   try {
-    const data = request.data as { eventId: string; eventData: any };
-    const context = request;
-    
     // Check authentication
     if (!context.auth) {
       throw new functions.https.HttpsError('unauthenticated', 'User must be authenticated');


### PR DESCRIPTION
## 🔧 Cloud Functions Authentication Fix

### Problem
- Event updates failing with 'User must be authenticated' errors
- Cloud Functions returning 401 status codes
- Parameter mismatch in adminUpdateEvent function

### Root Cause
- adminUpdateEvent function had incorrect parameter signature
- Used (request) instead of (data, context) for Firebase v1 callable functions
- This prevented proper authentication context from being passed

### Solution
- Fixed adminUpdateEvent parameter signature to match other functions
- Changed from (request) to (data, context)
- All Cloud Functions now have consistent parameter signatures

### Testing
- [ ] Test event creation
- [ ] Test event updates
- [ ] Test event capacity changes
- [ ] Test event location changes

### Impact
- ✅ Event editing should now work properly
- ✅ All Cloud Functions will have proper authentication
- ✅ No more 'User must be authenticated' errors

**Critical fix for event management functionality!** 🚀