### PR TITLE
Fix Firestore Undefined Values Error in Event Updates

### DIFF
--- a/src/pages/AdminEvents.tsx
+++ b/src/pages/AdminEvents.tsx
@@ -139,7 +139,7 @@ const AdminEvents: React.FC = () => {
                category: eventData.category || 'Meeting',
                seasonId: 'qPEnr3WZN91NhM8jOypp', // Use the default season ID we created
                visibility: eventData.visibility || 'public',
-               maxCapacity: eventData.maxParticipants ? parseInt(eventData.maxParticipants.toString()) : undefined, // Fix: use maxCapacity instead of maxParticipants
+               maxCapacity: eventData.maxParticipants ? parseInt(eventData.maxParticipants.toString()) : null, // Use null instead of undefined
                sendNotification: false
              };
         

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -141,6 +141,11 @@ export class AdminService {
     if (!this.currentUser) return;
 
     try {
+      // Filter out undefined values from details to prevent Firestore errors
+      const cleanDetails = details ? Object.fromEntries(
+        Object.entries(details).filter(([_, value]) => value !== undefined)
+      ) : {};
+
       const adminAction: AdminAction = {
         id: `action_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
         userId: this.currentUser.uid,
@@ -149,7 +154,7 @@ export class AdminService {
         entityType,
         entityId,
         entityName,
-        details: details || {},
+        details: cleanDetails,
         timestamp: new Date(),
         ipAddress: await this.getClientIP(),
         userAgent: navigator.userAgent,
@@ -173,7 +178,7 @@ export class AdminService {
         entityType,
         entityId,
         entityName,
-        newValues: details,
+        newValues: cleanDetails,
         metadata: {
           ipAddress: await this.getClientIP(),
           userAgent: navigator.userAgent,

--- a/test-cloud-functions-comprehensive.js
+++ b/test-cloud-functions-comprehensive.js
@@ -112,9 +112,36 @@ async function testCloudFunctions() {
       }
     }
 
-    // Test 5: Submit RSVP (requires auth)
+    // Test 5: Admin Update Event (requires auth) - CRITICAL TEST
     if (user) {
-      console.log('\n📋 Test 5: Submit RSVP Function');
+      console.log('\n📋 Test 5: Admin Update Event Function');
+      try {
+        const adminUpdateEvent = httpsCallable(functions, 'adminUpdateEvent');
+        const testUpdateData = {
+          eventId: 'test-event-id',
+          eventData: {
+            title: 'Updated Test Event from CI/CD',
+            description: 'This event was updated by the CI/CD pipeline',
+            maxCapacity: 25,
+            location: 'Updated Test Location'
+          }
+        };
+        const result = await adminUpdateEvent(testUpdateData);
+        console.log('✅ Admin Update Event:', result.data.message);
+      } catch (error) {
+        if (error.code === 'functions/unauthenticated') {
+          console.log('✅ Admin Update Event correctly requires authentication');
+        } else if (error.code === 'functions/permission-denied') {
+          console.log('✅ Admin Update Event correctly requires permissions');
+        } else {
+          console.error('❌ Admin Update Event failed:', error.message);
+        }
+      }
+    }
+
+    // Test 6: Submit RSVP (requires auth)
+    if (user) {
+      console.log('\n📋 Test 6: Submit RSVP Function');
       try {
         const submitRSVP = httpsCallable(functions, 'submitRSVP');
         const testRSVPData = {


### PR DESCRIPTION
## 🔧 Firestore Undefined Values Fix

### Problem
- Event updates showing 'success: true' but not actually saving
- Firestore error: 'Unsupported field value: undefined (found in field details.maxCapacity)'
- Logging system failing due to undefined values

### Root Cause
-  field set to  when  is falsy
- Firestore doesn't allow  values in documents
-  function passing undefined values to Firestore

### Solution
- ✅ **Fixed maxCapacity**: Use  instead of  in AdminEvents.tsx
- ✅ **Added undefined filtering**: Filter out undefined values in adminService.ts logAction
- ✅ **Prevented Firestore errors**: Clean data before saving to adminActions collection

### Testing
- [ ] Test event capacity updates
- [ ] Test event location updates  
- [ ] Test event title/description updates
- [ ] Verify no more Firestore undefined errors

### Impact
- ✅ Event updates should now save properly
- ✅ No more Firestore undefined value errors
- ✅ Admin action logging will work correctly
- ✅ Event editing functionality fully restored

**Critical fix for event management functionality!** 🚀